### PR TITLE
Add threading to Splash presenter

### DIFF
--- a/app/src/main/java/com/shagalalab/sozlik/helper/thread/AppExecutors.java
+++ b/app/src/main/java/com/shagalalab/sozlik/helper/thread/AppExecutors.java
@@ -1,0 +1,29 @@
+package com.shagalalab.sozlik.helper.thread;
+
+import java.util.concurrent.Executor;
+
+/**
+ * Created by atabek on 03/27/2018.
+ */
+
+public class AppExecutors {
+    private final Executor diskIo;
+    private final Executor mainThread;
+
+    private AppExecutors(Executor diskIo, Executor mainThread) {
+        this.diskIo = diskIo;
+        this.mainThread = mainThread;
+    }
+
+    public AppExecutors() {
+        this(new DiskIoThreadExecutor(), new MainThreadExecutor());
+    }
+
+    public Executor getDiskIo() {
+        return diskIo;
+    }
+
+    public Executor getMainThread() {
+        return mainThread;
+    }
+}

--- a/app/src/main/java/com/shagalalab/sozlik/helper/thread/DiskIoThreadExecutor.java
+++ b/app/src/main/java/com/shagalalab/sozlik/helper/thread/DiskIoThreadExecutor.java
@@ -1,0 +1,23 @@
+package com.shagalalab.sozlik.helper.thread;
+
+import android.support.annotation.NonNull;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+/**
+ * Created by atabek on 03/27/2018.
+ */
+
+public class DiskIoThreadExecutor implements Executor {
+    private final Executor diskIo;
+
+    public DiskIoThreadExecutor() {
+        this.diskIo = Executors.newSingleThreadExecutor();
+    }
+
+    @Override
+    public void execute(@NonNull Runnable command) {
+        diskIo.execute(command);
+    }
+}

--- a/app/src/main/java/com/shagalalab/sozlik/helper/thread/MainThreadExecutor.java
+++ b/app/src/main/java/com/shagalalab/sozlik/helper/thread/MainThreadExecutor.java
@@ -1,0 +1,20 @@
+package com.shagalalab.sozlik.helper.thread;
+
+import android.os.Handler;
+import android.os.Looper;
+import android.support.annotation.NonNull;
+
+import java.util.concurrent.Executor;
+
+/**
+ * Created by atabek on 03/27/2018.
+ */
+
+public class MainThreadExecutor implements Executor {
+    private Handler mainThreadHandler = new Handler(Looper.getMainLooper());
+
+    @Override
+    public void execute(@NonNull Runnable command) {
+        mainThreadHandler.post(command);
+    }
+}

--- a/app/src/main/java/com/shagalalab/sozlik/splash/SplashActivity.java
+++ b/app/src/main/java/com/shagalalab/sozlik/splash/SplashActivity.java
@@ -8,6 +8,7 @@ import android.support.v7.app.AppCompatActivity;
 import com.shagalalab.sozlik.MainActivity;
 import com.shagalalab.sozlik.helper.GsonHelper;
 import com.shagalalab.sozlik.helper.SharedPrefsHelper;
+import com.shagalalab.sozlik.helper.thread.AppExecutors;
 import com.shagalalab.sozlik.model.SozlikDatabase;
 
 public class SplashActivity extends AppCompatActivity implements SplashView {
@@ -19,7 +20,7 @@ public class SplashActivity extends AppCompatActivity implements SplashView {
         SharedPrefsHelper prefsHelper = new SharedPrefsHelper(this);
         SozlikDatabase database = SozlikDatabase.getSozlikDatabase(this);
 
-        SplashPresenter presenter = new SplashPresenter(this, gsonHelper, prefsHelper, database);
+        SplashPresenter presenter = new SplashPresenter(this, gsonHelper, prefsHelper, database.sozlikDao(), new AppExecutors());
         presenter.startSplash();
     }
 


### PR DESCRIPTION
Introduced threading to Splash presenter. Now, DB is populated in background thread, and when it finishes, it switches back to main thread. The idea is taken from google's [todo-mvp](https://github.com/googlesamples/android-architecture/tree/todo-mvp) sample app, and specifically these files:
- [AppExecutors.java](https://github.com/googlesamples/android-architecture/blob/todo-mvp/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/util/AppExecutors.java)
- [TasksLocalDataSource.java](https://github.com/googlesamples/android-architecture/blob/todo-mvp/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/local/TasksLocalDataSource.java)